### PR TITLE
Bugfix enpassant capture field

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -522,7 +522,7 @@ struct board {
                         if (rownumb == 3 && ((colnumb - 1) == enpassant[0] || (colnumb + 1) == enpassant[0])) {
                             moves.push_back({&piece, static_cast<unsigned int>(rownumb),
                                              static_cast<unsigned int>(colnumb), static_cast<unsigned int>(2),
-                                             static_cast<unsigned int>(enpassant[0]), 3, enpassant[0]});
+                                             static_cast<unsigned int>(enpassant[0]), 2, enpassant[0]});
                         }
                     } else {
                         // white
@@ -630,7 +630,7 @@ struct board {
                         if (rownumb == 4 && ((colnumb - 1) == enpassant[0] || (colnumb + 1) == enpassant[0])) {
                             moves.push_back({&piece, static_cast<unsigned int>(rownumb),
                                              static_cast<unsigned int>(colnumb), static_cast<unsigned int>(5),
-                                             static_cast<unsigned int>(enpassant[0]), 4, enpassant[0]});
+                                             static_cast<unsigned int>(enpassant[0]), 5, enpassant[0]});
                         }
                     }
                     break;


### PR DESCRIPTION
As debugged:

```c++
        { // one direction
            board.loadfen("r1b2bnr/1pqp1kp1/2p1pp2/p1P4p/1nBPP3/P7/1P1Q1PPP/RNB1K1NR b KQ - 0 12");
            board.move("b7b5");
            board.toggleWhoseToMove();
            board.draw();
            auto mvs = board.possibleMoves(/*{{4, 2}}, true*/);
            board.printMoveList(mvs);
            board.actuallyMove(mvs.back());
            board.draw();
        }
        { // one direction
            board = {};
            board.loadfen("r1b2bnr/1pqp1kp1/2p1pp2/p1P4p/1nBPP3/P7/1P1Q1PPP/RNB1K1NR b KQ - 0 12");
            board.move("b7b5");
            board.toggleWhoseToMove();
            board.draw();

            board.move("c5b6");
            board.toggleWhoseToMove();
            board.draw();
        }
```